### PR TITLE
remove append mode on hash file opening to allow running on read-only…

### DIFF
--- a/md5deep.py
+++ b/md5deep.py
@@ -9,7 +9,7 @@ import os, sys, hashlib
 # Optimized for low-memory systems, read whole file with blocksize=0
 def md5sum(filename, blocksize=65536):
     hash = hashlib.md5()
-    with open(filename, "r+b") as f:
+    with open(filename, "rb") as f:
         for block in iter(lambda: f.read(blocksize), ""):
             hash.update(block)
     return hash.hexdigest()


### PR DESCRIPTION
… media.
Cannot run validation test on read-only media with r+b mode.
